### PR TITLE
Unblock event loop in virus scan and cap clamdscan runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ ENV PATH="/app/.venv/bin:$PATH" \
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "uvicorn src.app.main:tc_av_app --host=0.0.0.0 --port=${PORT}"]
+CMD ["sh", "-c", "uvicorn src.app.main:tc_av_app --host=0.0.0.0 --port=${PORT} --workers 2"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn src.app.main:tc_av_app --host=0.0.0.0 --port=${PORT:-8000}
+web: uvicorn src.app.main:tc_av_app --host=0.0.0.0 --port=${PORT:-8000} --workers 2

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -117,27 +117,25 @@ class DocumentRequest(BaseModel):
         return json.dumps({'bucket': self.bucket, 'key': self.key}).encode()
 
 
-async def _object_is_deleted(s3_client, bucket: str, key: str) -> bool:
+def _object_is_deleted(s3_client, bucket: str, key: str) -> bool:
     """Return True if the object has been deleted (delete marker or missing)."""
     try:
-        await asyncio.to_thread(s3_client.head_object, Bucket=bucket, Key=key)
+        s3_client.head_object(Bucket=bucket, Key=key)
     except ClientError as e:
         error_code = e.response.get('Error', {}).get('Code')
         return error_code in ('NoSuchKey', '404', 'NotFound')
     return False
 
 
-async def _check_file(file_path: str, key: str) -> tuple[list, str]:
+def _check_file(file_path: str, key: str) -> tuple[list, str]:
     start = time.monotonic()
     try:
-        result = await asyncio.to_thread(
-            subprocess.run, _clamdscan_cmd(file_path), stdout=subprocess.PIPE, timeout=CLAMDSCAN_TIMEOUT_S
-        )
+        result = subprocess.run(_clamdscan_cmd(file_path), stdout=subprocess.PIPE, timeout=CLAMDSCAN_TIMEOUT_S)
     except subprocess.TimeoutExpired:
         logger.warning('clamdscan timed out on %s after %.2fs', key, time.monotonic() - start)
         return [], 'timeout'
     logger.info('clamdscan on %s took %.2fs', key, time.monotonic() - start)
-    output = result.stdout.decode()  # ty: ignore[unresolved-attribute]
+    output = result.stdout.decode()
     tags = []
     try:
         virus_msg = re.search(rf'{re.escape(file_path)}: (.*?)\n', output).group(1)  # ty: ignore[unresolved-attribute]
@@ -159,7 +157,7 @@ async def _check_file(file_path: str, key: str) -> tuple[list, str]:
 
 
 @tc_av_app.post('/check/')
-async def check_document(data: DocumentRequest):
+def check_document(data: DocumentRequest):
     assert settings.shared_secret_key, 'SHARED_SECRET_KEY is not set'
     assert settings.aws_access_key_id, 'AWS_ACCESS_KEY_ID is not set'
     assert settings.aws_secret_access_key, 'AWS_SECRET_KEY is not set'
@@ -172,18 +170,16 @@ async def check_document(data: DocumentRequest):
         aws_secret_access_key=settings.aws_secret_access_key,
     )
     file_path = f'tmp/{data.key.replace("/", "-")}'
-    await asyncio.to_thread(s3_client.download_file, Bucket=data.bucket, Key=data.key, Filename=file_path)
+    s3_client.download_file(Bucket=data.bucket, Key=data.key, Filename=file_path)
 
-    tags, status = await _check_file(file_path, data.key)
+    tags, status = _check_file(file_path, data.key)
     if tags:
         try:
-            await asyncio.to_thread(
-                s3_client.put_object_tagging, Bucket=data.bucket, Key=data.key, Tagging={'TagSet': tags}
-            )
+            s3_client.put_object_tagging(Bucket=data.bucket, Key=data.key, Tagging={'TagSet': tags})
         except ClientError as e:
             # Tagging a delete marker (object deleted in a versioned bucket between download and
             # tagging) raises MethodNotAllowed. Confirm the object really is gone; otherwise re-raise.
-            if not await _object_is_deleted(s3_client, data.bucket, data.key):
+            if not _object_is_deleted(s3_client, data.bucket, data.key):
                 raise
             logger.warning('Object %s was deleted before it could be tagged: %s', data.key, e)
             status = f'{status}-untagged'
@@ -195,8 +191,8 @@ async def check_document(data: DocumentRequest):
 
 
 @tc_av_app.get('/health/')
-async def health():
-    result = await asyncio.to_thread(subprocess.run, _clamdscan_cmd('--ping', '1'), capture_output=True)
+def health():
+    result = subprocess.run(_clamdscan_cmd('--ping', '1'), capture_output=True)
     if result.returncode != 0:
         raise HTTPException(status_code=503, detail='clamd is not responding')
     return {'status': 'ok'}

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -137,7 +137,7 @@ async def _check_file(file_path: str, key: str) -> tuple[list, str]:
         logger.warning('clamdscan timed out on %s after %.2fs', key, time.monotonic() - start)
         return [], 'timeout'
     logger.info('clamdscan on %s took %.2fs', key, time.monotonic() - start)
-    output = result.stdout.decode()
+    output = result.stdout.decode()  # ty: ignore[unresolved-attribute]
     tags = []
     try:
         virus_msg = re.search(rf'{re.escape(file_path)}: (.*?)\n', output).group(1)  # ty: ignore[unresolved-attribute]

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import subprocess
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 from secrets import compare_digest
@@ -127,13 +128,15 @@ async def _object_is_deleted(s3_client, bucket: str, key: str) -> bool:
 
 
 async def _check_file(file_path: str, key: str) -> tuple[list, str]:
+    start = time.monotonic()
     try:
         result = await asyncio.to_thread(
             subprocess.run, _clamdscan_cmd(file_path), stdout=subprocess.PIPE, timeout=CLAMDSCAN_TIMEOUT_S
         )
     except subprocess.TimeoutExpired:
-        logger.warning('clamdscan timed out on %s', key)
+        logger.warning('clamdscan timed out on %s after %.2fs', key, time.monotonic() - start)
         return [], 'timeout'
+    logger.info('clamdscan on %s took %.2fs', key, time.monotonic() - start)
     output = result.stdout.decode()
     tags = []
     try:

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -29,6 +29,7 @@ logger = logging.getLogger('tcav')
 Path('tmp').mkdir(exist_ok=True)
 
 CLAMD_CONFIG = 'src/clamd.conf'
+CLAMDSCAN_TIMEOUT_S = 60
 
 
 def _clamdscan_cmd(*args: str) -> list[str]:
@@ -115,18 +116,25 @@ class DocumentRequest(BaseModel):
         return json.dumps({'bucket': self.bucket, 'key': self.key}).encode()
 
 
-def _object_is_deleted(s3_client, bucket: str, key: str) -> bool:
+async def _object_is_deleted(s3_client, bucket: str, key: str) -> bool:
     """Return True if the object has been deleted (delete marker or missing)."""
     try:
-        s3_client.head_object(Bucket=bucket, Key=key)
+        await asyncio.to_thread(s3_client.head_object, Bucket=bucket, Key=key)
     except ClientError as e:
         error_code = e.response.get('Error', {}).get('Code')
         return error_code in ('NoSuchKey', '404', 'NotFound')
     return False
 
 
-def _check_file(file_path: str, key: str) -> tuple[list, str]:
-    output = subprocess.run(_clamdscan_cmd(file_path), stdout=subprocess.PIPE).stdout.decode()
+async def _check_file(file_path: str, key: str) -> tuple[list, str]:
+    try:
+        result = await asyncio.to_thread(
+            subprocess.run, _clamdscan_cmd(file_path), stdout=subprocess.PIPE, timeout=CLAMDSCAN_TIMEOUT_S
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning('clamdscan timed out on %s', key)
+        return [], 'timeout'
+    output = result.stdout.decode()
     tags = []
     try:
         virus_msg = re.search(rf'{re.escape(file_path)}: (.*?)\n', output).group(1)  # ty: ignore[unresolved-attribute]
@@ -161,16 +169,18 @@ async def check_document(data: DocumentRequest):
         aws_secret_access_key=settings.aws_secret_access_key,
     )
     file_path = f'tmp/{data.key.replace("/", "-")}'
-    s3_client.download_file(Bucket=data.bucket, Key=data.key, Filename=file_path)
+    await asyncio.to_thread(s3_client.download_file, Bucket=data.bucket, Key=data.key, Filename=file_path)
 
-    tags, status = _check_file(file_path, data.key)
+    tags, status = await _check_file(file_path, data.key)
     if tags:
         try:
-            s3_client.put_object_tagging(Bucket=data.bucket, Key=data.key, Tagging={'TagSet': tags})
+            await asyncio.to_thread(
+                s3_client.put_object_tagging, Bucket=data.bucket, Key=data.key, Tagging={'TagSet': tags}
+            )
         except ClientError as e:
             # Tagging a delete marker (object deleted in a versioned bucket between download and
             # tagging) raises MethodNotAllowed. Confirm the object really is gone; otherwise re-raise.
-            if not _object_is_deleted(s3_client, data.bucket, data.key):
+            if not await _object_is_deleted(s3_client, data.bucket, data.key):
                 raise
             logger.warning('Object %s was deleted before it could be tagged: %s', data.key, e)
             status = f'{status}-untagged'
@@ -183,7 +193,7 @@ async def check_document(data: DocumentRequest):
 
 @tc_av_app.get('/health/')
 async def health():
-    result = subprocess.run(_clamdscan_cmd('--ping', '1'), capture_output=True)
+    result = await asyncio.to_thread(subprocess.run, _clamdscan_cmd('--ping', '1'), capture_output=True)
     if result.returncode != 0:
         raise HTTPException(status_code=503, detail='clamd is not responding')
     return {'status': 'ok'}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -151,6 +151,21 @@ def test_check_error_file(client, monkeypatch):
     assert r.json() == {'status': 'error'}
 
 
+def test_check_timeout(client, monkeypatch):
+    monkeypatch.setattr(boto3, 'client', MockClient)
+
+    def fake_run(cmd, *args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get('timeout', 60))
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    tag_calls = []
+    monkeypatch.setattr(MockClient, 'put_object_tagging', lambda self, **kw: tag_calls.append(kw))
+    r = _post_check(client, {'bucket': 'aws_bucket', 'key': 'tests/files/clean_file'})
+    assert r.status_code == 200
+    assert r.json() == {'status': 'timeout'}
+    assert tag_calls == []
+
+
 def test_health_ok(client, monkeypatch):
     monkeypatch.setattr(subprocess, 'run', MockRun(returncode=0))
     r = client.get('/health/')


### PR DESCRIPTION
## Technical description for developers

Fixes 520s from Cloudflare reported as `HTTPError: 520 Server Error` in TC2 (Sentry issue [TC-SERVER-15WE](https://tutorcruncher.sentry.io/issues/TC-SERVER-15WE)). The TC2-side PR tutorcruncher/TutorCruncher2#16285 already swallows the downstream exception; this PR addresses the origin-side root cause.

**Root cause.** `check_document` was marked `async def` but every heavy call inside it was blocking sync code (`subprocess.run` for clamdscan, `s3_client.download_file`, `put_object_tagging`). On a single uvicorn worker that froze the event loop for the duration of each scan, so one slow scan blocked every other in-flight connection. Evidence in Render logs around the 2026-04-21 12:10 UTC and 2026-04-24 14:11 UTC Sentry events: silent request-log gaps spanning each 520, no restart/5xx/OOM, response times elevated to 3–5s on Apr 24 vs ~500ms normally. 520 (not 524) means Cloudflare got a malformed/truncated reply — consistent with the worker closing the connection mid-response, not a Cloudflare timeout.

**Changes:**
1. **Convert `check_document` / `health` / helpers to sync `def`.** FastAPI auto-dispatches sync `def` handlers to its internal threadpool, giving the same head-of-line-blocking fix as `asyncio.to_thread` with less noise. No behaviour change vs the intermediate `asyncio.to_thread` approach.
2. **60s clamdscan timeout.** On `subprocess.TimeoutExpired`, log a warning and return `{"status": "timeout"}` with HTTP 200 — so Cloudflare never sees a broken connection. For sizing: typical observed scan times are sub-second, worst observed ~5s, so 60s is a circuit breaker for genuine hangs not a normal cutoff.
3. **Log clamdscan duration** at INFO on every successful scan (`clamdscan on <key> took X.XXs`) so we can size the timeout from real prod data and tune down later if warranted.
4. **`--workers 2`** in the Dockerfile + Procfile. `pro` plan has 2 CPU / 4GB, so two workers is safe and gives parallelism even if one worker is tied up on a slow scan.
5. **Test** for the timeout path: mocks `subprocess.run` to raise `TimeoutExpired`, asserts 200 + `{"status": "timeout"}` and no tagging attempted.

## Description for non-devs

Fixes rare upload-scan errors under load. The virus-checking service now handles multiple file scans in parallel (previously one slow scan blocked everything else) and bails out cleanly if a scan stalls instead of breaking the connection.