### PR TITLE
Bound S3 calls with explicit timeouts

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -14,6 +14,7 @@ from secrets import compare_digest
 import boto3
 import logfire
 import sentry_sdk
+from botocore.config import Config
 from botocore.exceptions import ClientError
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
@@ -31,6 +32,9 @@ Path('tmp').mkdir(exist_ok=True)
 
 CLAMD_CONFIG = 'src/clamd.conf'
 CLAMDSCAN_TIMEOUT_S = 60
+# Bound S3 calls so a stalled connection bails before TC2's gunicorn worker timeout
+# (45s) kicks in. Default boto3 is 60s connect + 60s read with retries.
+S3_CONFIG = Config(connect_timeout=5, read_timeout=15, retries={'max_attempts': 2, 'mode': 'standard'})
 
 
 def _clamdscan_cmd(*args: str) -> list[str]:
@@ -168,9 +172,12 @@ def check_document(data: DocumentRequest):
         's3',
         aws_access_key_id=settings.aws_access_key_id,
         aws_secret_access_key=settings.aws_secret_access_key,
+        config=S3_CONFIG,
     )
     file_path = f'tmp/{data.key.replace("/", "-")}'
+    download_start = time.monotonic()
     s3_client.download_file(Bucket=data.bucket, Key=data.key, Filename=file_path)
+    logger.info('s3 download of %s took %.2fs', data.key, time.monotonic() - download_start)
 
     tags, status = _check_file(file_path, data.key)
     if tags:


### PR DESCRIPTION
## Technical description for developers

Follow-up to #380. A `/check/` request on 2026-04-24 18:59 UTC took **62 seconds** end-to-end (Logfire span: `POST /check/ duration=62.12s status=200`). The clamdscan log for the same file shows the actual scan ran in 0.15s — meaning ~62s was spent inside `s3_client.download_file` before clamdscan was even invoked. Boto3's defaults are `connect_timeout=60s`, `read_timeout=60s` with retries, so a stalled S3 read just sits there.

That overshot TC2's 45s gunicorn worker timeout (`gconfig.py: timeout = 45`) and caused TC2's worker to receive SIGABRT mid-`session.post()`, surfacing as Sentry [TC-SERVER-13AW](https://tutorcruncher.sentry.io/issues/TC-SERVER-13AW) (`SystemExit: 1` from `gunicorn/workers/base.py:198 in handle_abort`). The TC2-side fix (request timeout on `session.post`) is separate; this PR fixes the origin so individual S3 hiccups can't run past TC2's worker timeout in the first place.

**Changes:**
1. \`S3_CONFIG = Config(connect_timeout=5, read_timeout=15, retries={'max_attempts': 2, 'mode': 'standard'})\` passed to the boto3 client. Worst case becomes ~5 + 15×2 = 35s, comfortably under TC2's 45s.
2. Log the S3 download duration at INFO so we can see it in Logfire next time, the same way we log clamdscan duration.

## Description for non-devs

Stops rare cases where the virus checker waits forever for a stalled file download from S3, which was causing the TutorCruncher web request to time out and error.