### PR TITLE
Cap clamd scan work at the source for issue #383

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -132,13 +132,20 @@ def _object_is_deleted(s3_client, bucket: str, key: str) -> bool:
 
 
 def _check_file(file_path: str, key: str) -> tuple[list, str]:
-    start = time.monotonic()
     try:
-        result = subprocess.run(_clamdscan_cmd(file_path), stdout=subprocess.PIPE, timeout=CLAMDSCAN_TIMEOUT_S)
-    except subprocess.TimeoutExpired:
-        logger.warning('clamdscan timed out on %s after %.2fs', key, time.monotonic() - start)
-        return [], 'timeout'
-    logger.info('clamdscan on %s took %.2fs', key, time.monotonic() - start)
+        file_size = os.path.getsize(file_path)
+    except OSError:
+        file_size = -1
+    start = time.monotonic()
+    # Span duration + file_size lets us correlate slow scans against file characteristics
+    # in Logfire, which was the missing data needed to debug issue #383.
+    with logfire.span('clamdscan', key=key, file_size=file_size):
+        try:
+            result = subprocess.run(_clamdscan_cmd(file_path), stdout=subprocess.PIPE, timeout=CLAMDSCAN_TIMEOUT_S)
+        except subprocess.TimeoutExpired:
+            logger.warning('clamdscan timed out on %s after %.2fs (size=%d)', key, time.monotonic() - start, file_size)
+            return [], 'timeout'
+    logger.info('clamdscan on %s took %.2fs (size=%d)', key, time.monotonic() - start, file_size)
     output = result.stdout.decode()
     tags = []
     try:

--- a/src/clamd.conf
+++ b/src/clamd.conf
@@ -1,3 +1,13 @@
 LocalSocket /tmp/clamd.socket
 LogFile /tmp/clamav.log
 LocalSocketMode 660
+
+# Bail fast on pathological inputs (deeply nested PDFs, archive bombs, regex-heavy
+# content) rather than grinding through them. PDFs decompress to many MB of nested
+# objects, JS, and embedded streams; without these caps a single bad file can hold a
+# scan worker for 30-60s. See issue #383.
+MaxScanTime 20000
+MaxRecursion 10
+MaxFiles 1000
+PCREMatchLimit 10000
+PCRERecMatchLimit 1000


### PR DESCRIPTION
## Summary

Closes #383. Master already added a 60s subprocess timeout on `clamdscan` (#380), which stops gunicorn workers dying — but clamd still grinds for the full 60s on pathological PDFs before the outer timeout fires, and we have no per-scan attributes in Logfire to correlate slow scans against file characteristics. This PR addresses both.

## What we did

- **Tightened [src/clamd.conf](src/clamd.conf)** with caps that let clamd bail fast on bad inputs:
  - `MaxScanTime 20000` — hard internal cap (clamd kills the scan itself well before the 60s subprocess timeout fires).
  - `MaxRecursion 10`, `MaxFiles 1000` — stop deeply-nested PDFs / archive-in-PDF polyglots from running the recursion limit.
  - `PCREMatchLimit 10000`, `PCRERecMatchLimit 1000` — stop catastrophic backtracking on regex-heuristic rules running for seconds.
- **Wrapped `clamdscan` in a `logfire.span('clamdscan', key=key, file_size=file_size)`** in [src/app/main.py](src/app/main.py) so each scan emits its own span with duration + file size as attributes. This is the observability the issue called out as missing — we can now query Logfire for slow scans grouped by `file_size`. The existing text-log lines are preserved (size added).

Why these particular caps: PDFs decouple file-size from scan-cost. A 100 KB PDF can decompress to many MB of nested objects, embedded JS, attached files, even archive polyglots. Cost lives in decompression + recursion + PCRE work, not in raw bytes — which is why we saw 30-60s scans on small files in the issue. The new caps target each of those cost sources directly.

## Out of scope

- The 60s outer subprocess timeout / `'timeout'` status path — already on master via #380.
- Caller-side 10s `requests` timeout — already shipped in TC2.
- Reproducing with the specific slow file from the issue — better done after this lands so we can verify Logfire shows the new span attributes against real traffic.

## Test plan

- [ ] CI green on `fix/issue-383-clamd-limits`.
- [ ] After merge + deploy, query Logfire `clamdscan` spans over 24h and confirm `file_size` is populated and the p95/max duration drops vs. the table in the issue.
- [ ] Spot-check that the same agency's scans on the previously-slow PDF (`linkz/docs/uploads/b13083667e1d23ab2db603a34fcabba9.pdf`) now bail under `MaxScanTime` rather than running to the 60s subprocess timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)